### PR TITLE
clang tidy include cleaner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ cmake-build-*
 
 # Visual Studio code
 *.vscode
+
+#QtCreator
+*.txt.user

--- a/src/core/include/ecal/ecal_config.h
+++ b/src/core/include/ecal/ecal_config.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <ecal/ecal_log_level.h>
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_tlayer.h>
-#include <ecal/ecal_log_level.h>
 
 #include <string>
 

--- a/src/core/include/ecal/ecal_monitoring.h
+++ b/src/core/include/ecal/ecal_monitoring.h
@@ -26,6 +26,7 @@
 
 #include <ecal/ecal_os.h>
 #include <ecal/types/monitoring.h>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/include/ecal/ecal_publisher.h
+++ b/src/core/include/ecal/ecal_publisher.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
-#include <ecal/ecal_os.h>
-#include <ecal/ecal_deprecate.h>
+#include <cstddef>
 #include <ecal/ecal_callback.h>
+#include <ecal/ecal_deprecate.h>
+#include <ecal/ecal_os.h>
 #include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_types.h>
 

--- a/src/core/include/ecal/ecal_subscriber.h
+++ b/src/core/include/ecal/ecal_subscriber.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
-#include <ecal/ecal_os.h>
-#include <ecal/ecal_deprecate.h>
+#include <cstddef>
 #include <ecal/ecal_callback.h>
+#include <ecal/ecal_deprecate.h>
+#include <ecal/ecal_os.h>
 #include <ecal/ecal_types.h>
 
 #include <memory>

--- a/src/core/include/ecal/ecal_util.h
+++ b/src/core/include/ecal/ecal_util.h
@@ -30,11 +30,11 @@
 #include <ecal/ecal_types.h>
 
 #include <map>
-#include <unordered_map>
 #include <string>
 #include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-
 
 namespace eCAL
 {

--- a/src/core/include/ecal/msg/protobuf/dynamic_publisher.h
+++ b/src/core/include/ecal/msg/protobuf/dynamic_publisher.h
@@ -24,11 +24,17 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <ostream>
 #include <sstream>
 
 #include <ecal/ecal.h>
-#include <ecal/msg/publisher.h>
 #include <ecal/msg/protobuf/ecal_proto_hlp.h>
+#include <ecal/msg/publisher.h>
+#include <stdexcept>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/src/core/include/ecal/msg/protobuf/dynamic_subscriber.h
+++ b/src/core/include/ecal/msg/protobuf/dynamic_subscriber.h
@@ -30,8 +30,11 @@
 #include <ecal/msg/protobuf/ecal_proto_dyn.h>
 
 #include <exception>
+#include <functional>
 #include <memory>
+#include <ostream>
 #include <sstream>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/src/core/include/ecal/msg/protobuf/ecal_proto_hlp.h
+++ b/src/core/include/ecal/msg/protobuf/ecal_proto_hlp.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iterator>
 #include <string>
 #include <vector>
 

--- a/src/core/include/ecal/msg/protobuf/publisher.h
+++ b/src/core/include/ecal/msg/protobuf/publisher.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_deprecate.h>
-#include <ecal/msg/publisher.h>
 #include <ecal/msg/protobuf/ecal_proto_hlp.h>
+#include <ecal/msg/publisher.h>
 
 // protobuf includes
 #ifdef _MSC_VER

--- a/src/core/include/ecal/msg/protobuf/server.h
+++ b/src/core/include/ecal/msg/protobuf/server.h
@@ -25,8 +25,9 @@
 #pragma once
 
 #include <ecal/ecal_server.h>
-#include <ecal/msg/protobuf/ecal_proto_dyn.h>
 #include <ecal/msg/dynamic.h>
+#include <ecal/msg/protobuf/ecal_proto_dyn.h>
+#include <functional>
 
 // protobuf includes
 #ifdef _MSC_VER

--- a/src/core/include/ecal/msg/protobuf/subscriber.h
+++ b/src/core/include/ecal/msg/protobuf/subscriber.h
@@ -24,8 +24,9 @@
 
 #pragma once
 
-#include <ecal/msg/subscriber.h>
+#include <cstddef>
 #include <ecal/msg/protobuf/ecal_proto_hlp.h>
+#include <ecal/msg/subscriber.h>
 
 // protobuf includes
 #ifdef _MSC_VER

--- a/src/core/include/ecal/msg/string/publisher.h
+++ b/src/core/include/ecal/msg/string/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 

--- a/src/core/include/ecal/msg/string/subscriber.h
+++ b/src/core/include/ecal/msg/string/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/msg/subscriber.h>
 
 #include <string>

--- a/src/core/include/ecal/types/monitoring.h
+++ b/src/core/include/ecal/types/monitoring.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace eCAL
 {

--- a/src/core/src/config/ecal_config.cpp
+++ b/src/core/src/config/ecal_config.cpp
@@ -17,8 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_log_level.h>
+#include <string>
+#include <vector>
 
 #include "ecal_config_reader.h"
 #include "ecal_config_reader_hlp.h"

--- a/src/core/src/config/ecal_config_reader.cpp
+++ b/src/core/src/config/ecal_config_reader.cpp
@@ -21,8 +21,9 @@
  * @brief  Global config class
 **/
 
-#include <ecal/ecal_os.h>
+#include <cctype>
 #include <ecal/ecal_defs.h>
+#include <ecal/ecal_os.h>
 
 #include "ecal_def.h"
 #include "ecal_config_reader.h"
@@ -35,6 +36,8 @@
 #include <fstream>
 
 #include <ecal_utils/filesystem.h>
+#include <string>
+#include <vector>
 
 #ifdef ECAL_OS_LINUX
 #include <sys/types.h>

--- a/src/core/src/ecal.cpp
+++ b/src/core/src/ecal.cpp
@@ -22,8 +22,11 @@
 **/
 
 #include "ecal_def.h"
-#include "ecal_globals.h"
 #include "ecal_event.h"
+#include "ecal_globals.h"
+#include <cstddef>
+#include <string>
+#include <vector>
 
 #if ECAL_CORE_COMMAND_LINE
 #include "util/advanced_tclap_output.h"

--- a/src/core/src/ecal_descgate.cpp
+++ b/src/core/src/ecal_descgate.cpp
@@ -25,9 +25,14 @@
 #include <ecal/ecal_config.h>
 
 #include "ecal_descgate.h"
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/ecal_descgate.h
+++ b/src/core/src/ecal_descgate.h
@@ -23,21 +23,22 @@
 
 #pragma once
 
-#include <ecal/ecal_util.h>
+#include <chrono>
 #include <ecal/ecal_types.h>
+#include <ecal/ecal_util.h>
 
 #include "ecal_global_accessors.h"
 #include "ecal_def.h"
 #include "util/ecal_expmap.h"
 
+#include <map>
+#include <memory>
 #include <shared_mutex>
 #include <string>
-#include <map>
-#include <unordered_map>
-#include <memory>
 #include <tuple>
+#include <type_traits>
+#include <unordered_map>
 #include <vector>
-
 
 namespace eCAL
 {

--- a/src/core/src/ecal_event.cpp
+++ b/src/core/src/ecal_event.cpp
@@ -21,11 +21,14 @@
  * @brief  eCAL handle helper class
 **/
 
+#include <chrono>
+#include <cstdint>
 #include <ecal/ecal_os.h>
 
 #include "ecal_event.h"
 
 #include <sstream>
+#include <string>
 
 #ifdef ECAL_OS_WINDOWS
 

--- a/src/core/src/ecal_global_accessors.cpp
+++ b/src/core/src/ecal_global_accessors.cpp
@@ -21,9 +21,11 @@
  * @brief  eCAL core functions
 **/
 
-#include "ecal_def.h"
 #include "ecal_global_accessors.h"
+#include "ecal_def.h"
 #include "ecal_globals.h"
+#include <atomic>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/ecal_globals.cpp
+++ b/src/core/src/ecal_globals.cpp
@@ -26,7 +26,10 @@
 #include "config/ecal_config_reader.h"
 
 #include <iostream>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #if ECAL_CORE_SERVICE
 #include "service/ecal_service_singleton_manager.h"

--- a/src/core/src/ecal_globals.h
+++ b/src/core/src/ecal_globals.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include "ecal_global_accessors.h"
+#include <string>
+#include <vector>
 #if ECAL_CORE_REGISTRATION
 #include "registration/ecal_registration_provider.h"
 #include "registration/ecal_registration_receiver.h"

--- a/src/core/src/ecal_process.cpp
+++ b/src/core/src/ecal_process.cpp
@@ -21,6 +21,7 @@
 * @brief  eCAL process interface
 **/
 
+#include <cstdint>
 #include <ecal/ecal.h>
 
 #include "ecal_def.h"
@@ -38,15 +39,16 @@
 #include <array>
 #include <atomic>
 #include <chrono>
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 #ifdef ECAL_OS_WINDOWS
 #include "ecal_win_main.h"

--- a/src/core/src/ecal_process_stub.cpp
+++ b/src/core/src/ecal_process_stub.cpp
@@ -17,10 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <errno.h>
+#include <string>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <errno.h>
 
 #include <string.h>
 #include <iostream>

--- a/src/core/src/ecal_util.cpp
+++ b/src/core/src/ecal_util.cpp
@@ -23,7 +23,12 @@
 #include "pubsub/ecal_pubgate.h"
 
 #include <list>
+#include <map>
 #include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/ecalc.cpp
+++ b/src/core/src/ecalc.cpp
@@ -21,10 +21,15 @@
  * @brief  Implementation of the eCAL dll interface
 **/
 
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
 #include <mutex>
 
 #include <ecal/ecal.h>
 #include <ecal/ecalc.h>
+#include <set>
+#include <string>
 
 static int CopyBuffer(void* target_, int target_len_, const std::string& source_s_)
 {

--- a/src/core/src/io/mtx/ecal_named_mutex.cpp
+++ b/src/core/src/io/mtx/ecal_named_mutex.cpp
@@ -21,7 +21,10 @@
  * @brief  eCAL named mutex
 **/
 
+#include <cstdint>
 #include <ecal/ecal_os.h>
+#include <memory>
+#include <string>
 
 #include "ecal_named_mutex.h"
 

--- a/src/core/src/io/mtx/linux/ecal_named_mutex_impl.h
+++ b/src/core/src/io/mtx/linux/ecal_named_mutex_impl.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include "io/mtx/ecal_named_mutex_base.h"
+#include <cstdint>
+#include <string>
 
 typedef struct named_mutex named_mutex_t;
 

--- a/src/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.h
+++ b/src/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include "io/mtx/ecal_named_mutex_base.h"
+#include <cstdint>
+#include <string>
 
 typedef struct named_mutex named_mutex_t;
 

--- a/src/core/src/io/shm/ecal_memfile.cpp
+++ b/src/core/src/io/shm/ecal_memfile.cpp
@@ -26,10 +26,11 @@
 #include "ecal_memfile_info.h"
 #include "ecal_memfile_db.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
-#include <algorithm>
 #include <random>
 
 #define SIZEOF_PARTIAL_STRUCT(_STRUCT_NAME_, _FIELD_NAME_) (reinterpret_cast<std::size_t>(&(reinterpret_cast<_STRUCT_NAME_*>(0)->_FIELD_NAME_)) + sizeof(_STRUCT_NAME_::_FIELD_NAME_)) //NOLINT

--- a/src/core/src/io/shm/ecal_memfile.h
+++ b/src/core/src/io/shm/ecal_memfile.h
@@ -23,9 +23,10 @@
 
 #pragma once
 
-#include <string>
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include <ecal/ecal_payload_writer.h>
 

--- a/src/core/src/io/shm/ecal_memfile_db.cpp
+++ b/src/core/src/io/shm/ecal_memfile_db.cpp
@@ -26,6 +26,9 @@
 #include "ecal_memfile_db.h"
 
 #include <cassert>
+#include <cstddef>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/io/shm/ecal_memfile_db.h
+++ b/src/core/src/io/shm/ecal_memfile_db.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <mutex>
 #include <string>
 #include <unordered_map>

--- a/src/core/src/io/shm/ecal_memfile_info.h
+++ b/src/core/src/io/shm/ecal_memfile_info.h
@@ -23,8 +23,9 @@
 
 #pragma once
 
-#include <string>
+#include <cstddef>
 #include <memory>
+#include <string>
 
 #include <ecal/ecal_os.h>
 

--- a/src/core/src/io/shm/ecal_memfile_naming.cpp
+++ b/src/core/src/io/shm/ecal_memfile_naming.cpp
@@ -20,9 +20,11 @@
 #include "io/shm/ecal_memfile_naming.h"
 
 #include <cstdint>
+#include <ios>
 #include <limits>
 #include <random>
 #include <sstream>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/io/shm/ecal_memfile_os.h
+++ b/src/core/src/io/shm/ecal_memfile_os.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "ecal_memfile.h"

--- a/src/core/src/io/shm/ecal_memfile_pool.cpp
+++ b/src/core/src/io/shm/ecal_memfile_pool.cpp
@@ -26,7 +26,15 @@
 #include "ecal_event.h"
 #include "ecal_memfile_pool.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/io/shm/ecal_memfile_pool.h
+++ b/src/core/src/io/shm/ecal_memfile_pool.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
 #include <ecal/ecal_log.h>
 
 #include "ecal_event.h"
@@ -35,6 +37,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace eCAL

--- a/src/core/src/io/shm/ecal_memfile_sync.cpp
+++ b/src/core/src/io/shm/ecal_memfile_sync.cpp
@@ -21,6 +21,8 @@
  * @brief  synchronized memory file interface
 **/
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/ecal_log.h>
 
 #include "ecal_event.h"
@@ -29,7 +31,10 @@
 #include "ecal_memfile_sync.h"
 
 #include <chrono>
+#include <mutex>
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace eCAL
 {

--- a/src/core/src/io/shm/ecal_memfile_sync.h
+++ b/src/core/src/io/shm/ecal_memfile_sync.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/ecal_payload_writer.h>
 
 #include "readwrite/ecal_writer_data.h"

--- a/src/core/src/io/shm/linux/ecal_memfile_os.cpp
+++ b/src/core/src/io/shm/linux/ecal_memfile_os.cpp
@@ -26,12 +26,13 @@
 #include <iostream>
 #include <string.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace eCAL
 {

--- a/src/core/src/io/udp/ecal_udp_configurations.cpp
+++ b/src/core/src/io/udp/ecal_udp_configurations.cpp
@@ -23,6 +23,7 @@
 #include "ecal_udp_topic2mcast.h"
 
 #include <ecal/ecal_config.h>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/io/udp/ecal_udp_sample_receiver.cpp
+++ b/src/core/src/io/udp/ecal_udp_sample_receiver.cpp
@@ -24,10 +24,14 @@
 #include "ecal_udp_sample_receiver.h"
 #include "io/udp/fragmentation/msg_type.h"
 
+#include <chrono>
 #include <ecal/ecal_log.h>
 
 #include <cstring>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/io/udp/ecal_udp_sample_receiver.h
+++ b/src/core/src/io/udp/ecal_udp_sample_receiver.h
@@ -28,6 +28,8 @@
 #include "util/ecal_thread.h"
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/src/core/src/io/udp/ecal_udp_sample_sender.cpp
+++ b/src/core/src/io/udp/ecal_udp_sample_sender.cpp
@@ -24,7 +24,13 @@
 #include "ecal_udp_sample_sender.h"
 #include "io/udp/fragmentation/snd_fragments.h"
 
+#include <cstddef>
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/io/udp/ecal_udp_sample_sender.h
+++ b/src/core/src/io/udp/ecal_udp_sample_sender.h
@@ -25,6 +25,7 @@
 
 #include "io/udp/sendreceive/udp_sender.h"
 
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/src/core/src/io/udp/ecal_udp_topic2mcast.h
+++ b/src/core/src/io/udp/ecal_udp_topic2mcast.h
@@ -23,11 +23,13 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <sstream>
+#include <cstdlib>
 #include <iostream>
+#include <sstream>
 #include <string>
- 
+
 namespace eCAL
 {
   namespace UDP

--- a/src/core/src/io/udp/fragmentation/rcv_fragments.cpp
+++ b/src/core/src/io/udp/fragmentation/rcv_fragments.cpp
@@ -25,9 +25,12 @@
 #include "rcv_fragments.h"
 #include "msg_type.h"
 
+#include <chrono>
 #include <ecal/ecal_log.h>
 
 #include <cstring>
+#include <string>
+#include <utility>
 
 namespace IO
 {

--- a/src/core/src/io/udp/fragmentation/rcv_fragments.h
+++ b/src/core/src/io/udp/fragmentation/rcv_fragments.h
@@ -26,6 +26,7 @@
 #include "ecal_def.h"
 
 #include <chrono>
+#include <cstdint>
 #include <vector>
 
 namespace IO

--- a/src/core/src/io/udp/fragmentation/snd_fragments.cpp
+++ b/src/core/src/io/udp/fragmentation/snd_fragments.cpp
@@ -25,9 +25,12 @@
 #include "msg_type.h"
 
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/io/udp/fragmentation/snd_fragments.h
+++ b/src/core/src/io/udp/fragmentation/snd_fragments.h
@@ -21,6 +21,7 @@
  * @brief  raw message buffer handling
 **/
 
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <vector>

--- a/src/core/src/io/udp/sendreceive/udp_receiver.cpp
+++ b/src/core/src/io/udp/sendreceive/udp_receiver.cpp
@@ -25,6 +25,9 @@
 #include "io/udp/ecal_udp_configurations.h"
 
 #include "udp_receiver_asio.h"
+#include <cstddef>
+#include <memory>
+#include <mutex>
 #ifdef ECAL_CORE_NPCAP_SUPPORT
 #include "udp_receiver_npcap.h"
 #endif

--- a/src/core/src/io/udp/sendreceive/udp_receiver.h
+++ b/src/core/src/io/udp/sendreceive/udp_receiver.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_os.h>
 
 #ifdef ECAL_OS_WINDOWS

--- a/src/core/src/io/udp/sendreceive/udp_receiver_asio.cpp
+++ b/src/core/src/io/udp/sendreceive/udp_receiver_asio.cpp
@@ -21,6 +21,8 @@
 #include "udp_receiver_asio.h"
 
 #include "io/udp/ecal_udp_configurations.h"
+#include <cstddef>
+#include <cstring>
 
 #ifdef __linux__
 #include "linux/socket_os.h"

--- a/src/core/src/io/udp/sendreceive/udp_receiver_asio.h
+++ b/src/core/src/io/udp/sendreceive/udp_receiver_asio.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "udp_receiver.h"
+#include <cstddef>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/src/core/src/io/udp/sendreceive/udp_sender.cpp
+++ b/src/core/src/io/udp/sendreceive/udp_sender.cpp
@@ -23,7 +23,9 @@
 
 #include "udp_sender.h"
 
+#include <cstddef>
 #include <iostream>
+#include <memory>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/src/core/src/io/udp/sendreceive/udp_sender.h
+++ b/src/core/src/io/udp/sendreceive/udp_sender.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_os.h>
 
 #ifdef ECAL_OS_WINDOWS

--- a/src/core/src/logging/ecal_log.cpp
+++ b/src/core/src/logging/ecal_log.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal.h>
+#include <string>
 
 #include "ecal_log_impl.h"
 

--- a/src/core/src/logging/ecal_log_impl.h
+++ b/src/core/src/logging/ecal_log_impl.h
@@ -27,6 +27,7 @@
 #include "io/udp/ecal_udp_sample_sender.h"
 #include "serialization/ecal_struct_logging.h"
 
+#include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_os.h>
 
@@ -36,8 +37,9 @@
 
 #include <atomic>
 #include <list>
-#include <mutex>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <vector>
 
 namespace eCAL

--- a/src/core/src/pubsub/ecal_pubgate.cpp
+++ b/src/core/src/pubsub/ecal_pubgate.cpp
@@ -25,8 +25,13 @@
 #include "ecal_sample_to_topicinfo.h"
 #include "ecal_globals.h"
 
-#include <iterator>
 #include <atomic>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <utility>
 
 namespace
 {

--- a/src/core/src/pubsub/ecal_pubgate.h
+++ b/src/core/src/pubsub/ecal_pubgate.h
@@ -27,8 +27,9 @@
 #include "serialization/ecal_struct_sample_registration.h"
 
 #include <atomic>
-#include <shared_mutex>
+#include <map>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 

--- a/src/core/src/pubsub/ecal_publisher.cpp
+++ b/src/core/src/pubsub/ecal_publisher.cpp
@@ -21,14 +21,18 @@
  * @brief  common data publisher based on eCAL
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
 
 #include "ecal_globals.h"
 #include "readwrite/ecal_writer.h"
 #include "readwrite/ecal_writer_buffer_payload.h"
 
-#include <sstream>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
 
 namespace
 {

--- a/src/core/src/pubsub/ecal_subgate.cpp
+++ b/src/core/src/pubsub/ecal_subgate.cpp
@@ -26,7 +26,15 @@
 #include "ecal_globals.h"
 
 #include <algorithm>
+#include <atomic>
+#include <cstddef>
 #include <iterator>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/pubsub/ecal_subgate.h
+++ b/src/core/src/pubsub/ecal_subgate.h
@@ -26,8 +26,9 @@
 #include "readwrite/ecal_reader.h"
 
 #include <atomic>
-#include <shared_mutex>
+#include <cstddef>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 

--- a/src/core/src/pubsub/ecal_subscriber.cpp
+++ b/src/core/src/pubsub/ecal_subscriber.cpp
@@ -21,13 +21,17 @@
  * @brief  common data subscriber for eCAL
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
 
 #include "ecal_globals.h"
 #include "readwrite/ecal_reader.h"
 
-#include <sstream>
 #include <iostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
 
 namespace
 {

--- a/src/core/src/readwrite/ecal_reader.cpp
+++ b/src/core/src/readwrite/ecal_reader.cpp
@@ -21,8 +21,13 @@
  * @brief  common eCAL data reader
 **/
 
+#include <chrono>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
 
 #if ECAL_CORE_REGISTRATION
 #include "registration/ecal_registration_provider.h"

--- a/src/core/src/readwrite/ecal_reader.h
+++ b/src/core/src/readwrite/ecal_reader.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <deque>
 #include <ecal/ecal.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_types.h>
@@ -32,6 +35,7 @@
 #include "util/ecal_expmap.h"
 
 #include <condition_variable>
+#include <map>
 #include <mutex>
 #include <atomic>
 #include <set>

--- a/src/core/src/readwrite/ecal_writer.cpp
+++ b/src/core/src/readwrite/ecal_writer.cpp
@@ -21,9 +21,15 @@
  * @brief  common eCAL data writer
 **/
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_payload_writer.h>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <utility>
 
 #include "ecal_def.h"
 #include "config/ecal_config_reader_hlp.h"

--- a/src/core/src/readwrite/ecal_writer.h
+++ b/src/core/src/readwrite/ecal_writer.h
@@ -23,10 +23,13 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_tlayer.h>
 #include <ecal/ecal_types.h>
+#include <tuple>
 
 #include "ecal_def.h"
 #include "util/ecal_expmap.h"

--- a/src/core/src/readwrite/shm/ecal_reader_shm.cpp
+++ b/src/core/src/readwrite/shm/ecal_reader_shm.cpp
@@ -21,7 +21,10 @@
  * @brief  shared memory layer
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
+#include <functional>
+#include <string>
 
 #include "ecal_global_accessors.h"
 #include "pubsub/ecal_subgate.h"

--- a/src/core/src/readwrite/shm/ecal_reader_shm.h
+++ b/src/core/src/readwrite/shm/ecal_reader_shm.h
@@ -26,7 +26,9 @@
 #include "ecal_def.h"
 #include "readwrite/ecal_reader_layer.h"
 
+#include <cstddef>
 #include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/src/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -21,9 +21,11 @@
  * @brief  memory file data writer
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_log.h>
+#include <string>
 
 #include "ecal_def.h"
 #include "ecal_writer_shm.h"

--- a/src/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/src/core/src/readwrite/shm/ecal_writer_shm.h
@@ -26,8 +26,10 @@
 #include "readwrite/ecal_writer_base.h"
 #include "io/shm/ecal_memfile_sync.h"
 
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/readwrite/udp/ecal_reader_udp_mc.cpp
+++ b/src/core/src/readwrite/udp/ecal_reader_udp_mc.cpp
@@ -27,6 +27,11 @@
 #include "pubsub/ecal_subgate.h"
 
 #include "io/udp/ecal_udp_configurations.h"
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
 
 namespace eCAL
 {

--- a/src/core/src/readwrite/udp/ecal_reader_udp_mc.h
+++ b/src/core/src/readwrite/udp/ecal_reader_udp_mc.h
@@ -26,6 +26,7 @@
 #include "io/udp/ecal_udp_sample_receiver.h"
 #include "readwrite/ecal_reader_layer.h"
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/core/src/readwrite/udp/ecal_writer_udp_mc.cpp
+++ b/src/core/src/readwrite/udp/ecal_writer_udp_mc.cpp
@@ -21,8 +21,11 @@
  * @brief  udp data writer
 **/
 
-#include <ecal/ecal_log.h>
+#include <cstddef>
 #include <ecal/ecal_config.h>
+#include <ecal/ecal_log.h>
+#include <memory>
+#include <string>
 
 #include "ecal_writer_udp_mc.h"
 #include "io/udp/ecal_udp_configurations.h"

--- a/src/core/src/readwrite/udp/ecal_writer_udp_mc.h
+++ b/src/core/src/readwrite/udp/ecal_writer_udp_mc.h
@@ -26,6 +26,7 @@
 #include "io/udp/ecal_udp_sample_sender.h"
 #include "readwrite/ecal_writer_base.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/core/src/registration/ecal_registration_provider.cpp
+++ b/src/core/src/registration/ecal_registration_provider.cpp
@@ -26,6 +26,7 @@
  * 
 **/
 
+#include <atomic>
 #include <ecal/ecal_config.h>
 
 #include "ecal_def.h"
@@ -36,6 +37,11 @@
 #include "io/udp/ecal_udp_sample_sender.h"
 
 #include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace
 {

--- a/src/core/src/registration/ecal_registration_receiver.cpp
+++ b/src/core/src/registration/ecal_registration_receiver.cpp
@@ -32,8 +32,13 @@
 #include "pubsub/ecal_pubgate.h"
 #include "service/ecal_clientgate.h"
 
-#include "io/udp/ecal_udp_configurations.h"
 #include "ecal_sample_to_topicinfo.h"
+#include "io/udp/ecal_udp_configurations.h"
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/registration/ecal_registration_receiver.h
+++ b/src/core/src/registration/ecal_registration_receiver.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal.h>
 
 #include "ecal_def.h"

--- a/src/core/src/registration/ecal_registration_receiver_shm.cpp
+++ b/src/core/src/registration/ecal_registration_receiver_shm.cpp
@@ -29,6 +29,9 @@
 
 #include "ecal_registration_receiver_shm.h"
 #include "serialization/ecal_serialize_sample_registration.h"
+#include <chrono>
+#include <functional>
+#include <memory>
 
 namespace eCAL
 {

--- a/src/core/src/registration/ecal_registration_receiver_shm.h
+++ b/src/core/src/registration/ecal_registration_receiver_shm.h
@@ -31,6 +31,7 @@
 #include "shm/ecal_memfile_broadcast_reader.h"
 
 #include "util/ecal_thread.h"
+#include <memory>
 
 namespace eCAL
 {

--- a/src/core/src/registration/shm/ecal_memfile_broadcast.cpp
+++ b/src/core/src/registration/shm/ecal_memfile_broadcast.cpp
@@ -27,8 +27,12 @@
 #include "io/shm/ecal_memfile.h"
 #include "ecal_global_accessors.h"
 
-#include <iostream>
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/src/core/src/registration/shm/ecal_memfile_broadcast.h
+++ b/src/core/src/registration/shm/ecal_memfile_broadcast.h
@@ -23,11 +23,12 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <cstring>
-#include <cstdint>
 
 #include "relocatable_circular_queue.h"
 #include "io/shm/ecal_memfile.h"

--- a/src/core/src/registration/shm/ecal_memfile_broadcast_reader.cpp
+++ b/src/core/src/registration/shm/ecal_memfile_broadcast_reader.cpp
@@ -22,8 +22,14 @@
 **/
 
 #include "ecal_memfile_broadcast_reader.h"
-#include "io/shm/ecal_memfile.h"
 #include "ecal_def.h"
+#include "io/shm/ecal_memfile.h"
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <tuple>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/registration/shm/ecal_memfile_broadcast_reader.h
+++ b/src/core/src/registration/shm/ecal_memfile_broadcast_reader.h
@@ -25,10 +25,11 @@
 
 #include "ecal_memfile_broadcast.h"
 
+#include <cstddef>
 #include <cstdint>
-#include <vector>
-#include <unordered_map>
 #include <memory>
+#include <unordered_map>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/registration/shm/ecal_memfile_broadcast_writer.cpp
+++ b/src/core/src/registration/shm/ecal_memfile_broadcast_writer.cpp
@@ -22,8 +22,11 @@
 **/
 
 #include "ecal_memfile_broadcast_writer.h"
-#include "io/shm/ecal_memfile.h"
 #include "ecal_def.h"
+#include "io/shm/ecal_memfile.h"
+#include <iostream>
+#include <memory>
+#include <utility>
 
 namespace eCAL
 {

--- a/src/core/src/registration/shm/ecal_memfile_broadcast_writer.h
+++ b/src/core/src/registration/shm/ecal_memfile_broadcast_writer.h
@@ -25,6 +25,7 @@
 
 #include "ecal_memfile_broadcast.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/src/core/src/registration/shm/relocatable_circular_queue.h
+++ b/src/core/src/registration/shm/relocatable_circular_queue.h
@@ -23,11 +23,12 @@
 
 #pragma once
 
-#include <cstdint>
-#include <stdexcept>
-#include <limits>
-#include <iterator>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
 
 template<class T>
 class RelocatableCircularQueue{

--- a/src/core/src/serialization/ecal_serialize_common.cpp
+++ b/src/core/src/serialization/ecal_serialize_common.cpp
@@ -22,9 +22,13 @@
  * @brief  eCAL common (de)serialization
 **/
 
-#include "nanopb/pb_encode.h"
-#include "nanopb/pb_decode.h"
 #include "nanopb/ecal.pb.h"
+#include "nanopb/pb_decode.h"
+#include "nanopb/pb_encode.h"
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
 
 #include "ecal_serialize_common.h"
 

--- a/src/core/src/serialization/ecal_serialize_common.h
+++ b/src/core/src/serialization/ecal_serialize_common.h
@@ -31,6 +31,8 @@
 #include "ecal_struct_sample_registration.h"
 #include "ecal_struct_service.h"
 
+#include <cstddef>
+#include <map>
 #include <string>
 #include <vector>
 

--- a/src/core/src/serialization/ecal_serialize_logging.cpp
+++ b/src/core/src/serialization/ecal_serialize_logging.cpp
@@ -29,7 +29,11 @@
 #include "ecal_serialize_common.h"
 #include "ecal_serialize_logging.h"
 
+#include <cstddef>
 #include <iostream>
+#include <list>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/serialization/ecal_serialize_monitoring.cpp
+++ b/src/core/src/serialization/ecal_serialize_monitoring.cpp
@@ -29,7 +29,9 @@
 #include "ecal_serialize_common.h"
 #include "ecal_serialize_monitoring.h"
 
+#include <cstddef>
 #include <iostream>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/serialization/ecal_serialize_monitoring.h
+++ b/src/core/src/serialization/ecal_serialize_monitoring.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/types/monitoring.h>
 
 #include <string>

--- a/src/core/src/serialization/ecal_serialize_sample_payload.cpp
+++ b/src/core/src/serialization/ecal_serialize_sample_payload.cpp
@@ -29,7 +29,10 @@
 #include "ecal_serialize_common.h"
 #include "ecal_struct_sample_payload.h"
 
+#include <cstddef>
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/serialization/ecal_serialize_sample_payload.h
+++ b/src/core/src/serialization/ecal_serialize_sample_payload.h
@@ -26,6 +26,7 @@
 
 #include "ecal_struct_sample_payload.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/core/src/serialization/ecal_serialize_sample_registration.cpp
+++ b/src/core/src/serialization/ecal_serialize_sample_registration.cpp
@@ -29,7 +29,11 @@
 #include "ecal_serialize_common.h"
 #include "ecal_serialize_sample_registration.h"
 
+#include <cstddef>
 #include <iostream>
+#include <list>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/serialization/ecal_serialize_sample_registration.h
+++ b/src/core/src/serialization/ecal_serialize_sample_registration.h
@@ -26,6 +26,7 @@
 
 #include "ecal_struct_sample_registration.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/core/src/serialization/ecal_serialize_service.cpp
+++ b/src/core/src/serialization/ecal_serialize_service.cpp
@@ -29,7 +29,10 @@
 #include "ecal_serialize_common.h"
 #include "ecal_serialize_service.h"
 
+#include <cstddef>
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/serialization/ecal_serialize_service.h
+++ b/src/core/src/serialization/ecal_serialize_service.h
@@ -26,6 +26,7 @@
 
 #include "ecal_struct_service.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/core/src/serialization/ecal_struct_sample_payload.h
+++ b/src/core/src/serialization/ecal_struct_sample_payload.h
@@ -26,6 +26,8 @@
 
 #include "ecal_struct_sample_common.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/core/src/serialization/ecal_struct_sample_registration.h
+++ b/src/core/src/serialization/ecal_struct_sample_registration.h
@@ -27,6 +27,7 @@
 #include "ecal_struct_sample_common.h"
 #include "ecal_struct_service.h"
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <string>

--- a/src/core/src/serialization/ecal_struct_service.h
+++ b/src/core/src/serialization/ecal_struct_service.h
@@ -26,6 +26,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace eCAL
 {

--- a/src/core/src/service/ecal_clientgate.cpp
+++ b/src/core/src/service/ecal_clientgate.cpp
@@ -24,6 +24,11 @@
 #include "ecal_clientgate.h"
 #include "ecal_descgate.h"
 #include "service/ecal_service_client_impl.h"
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/src/core/src/service/ecal_clientgate.h
+++ b/src/core/src/service/ecal_clientgate.h
@@ -30,8 +30,10 @@
 #include <ecal/ecal_callback.h>
 
 #include <atomic>
-#include <shared_mutex>
 #include <set>
+#include <shared_mutex>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/service/ecal_service_client.cpp
+++ b/src/core/src/service/ecal_service_client.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal.h>
+#include <string>
 
 #include "ecal_clientgate.h"
 #include "ecal_global_accessors.h"

--- a/src/core/src/service/ecal_service_client_impl.cpp
+++ b/src/core/src/service/ecal_service_client_impl.cpp
@@ -30,8 +30,12 @@
 #include "serialization/ecal_serialize_service.h"
 
 #include <chrono>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/service/ecal_service_server.cpp
+++ b/src/core/src/service/ecal_service_server.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal.h>
+#include <string>
 
 #include "ecal_servicegate.h"
 #include "ecal_global_accessors.h"

--- a/src/core/src/service/ecal_service_server_impl.cpp
+++ b/src/core/src/service/ecal_service_server_impl.cpp
@@ -33,7 +33,10 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
 #include <utility>
 
 namespace

--- a/src/core/src/service/ecal_service_server_impl.h
+++ b/src/core/src/service/ecal_service_server_impl.h
@@ -28,9 +28,11 @@
 #include <ecal/ecal_service_info.h>
 
 #include <map>
+#include <memory>
 #include <mutex>
 
 #include <ecal/service/server.h>
+#include <string>
 
 #include "serialization/ecal_struct_service.h"
 

--- a/src/core/src/service/ecal_service_singleton_manager.cpp
+++ b/src/core/src/service/ecal_service_singleton_manager.cpp
@@ -19,7 +19,12 @@
 
 #include "ecal_service_singleton_manager.h"
 
+#include <cstddef>
 #include <ecal/ecal_log.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
 
 namespace eCAL
 {

--- a/src/core/src/service/ecal_service_singleton_manager.h
+++ b/src/core/src/service/ecal_service_singleton_manager.h
@@ -19,10 +19,15 @@
 
 #pragma once
 
-#include <ecal/service/server_manager.h>
+#include <atomic>
+#include <cstddef>
 #include <ecal/service/client_manager.h>
+#include <ecal/service/server_manager.h>
 
 #include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/core/src/service/ecal_servicegate.cpp
+++ b/src/core/src/service/ecal_servicegate.cpp
@@ -23,6 +23,9 @@
 
 #include "ecal_servicegate.h"
 #include "service/ecal_service_server_impl.h"
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
 
 namespace eCAL
 {

--- a/src/core/src/time/ecal_time.cpp
+++ b/src/core/src/time/ecal_time.cpp
@@ -24,6 +24,7 @@
 #include <ecal/ecal.h>
 
 #include <chrono>
+#include <string>
 #include <thread>
 
 #if ECAL_CORE_TIMEGATE

--- a/src/core/src/time/ecal_timegate.cpp
+++ b/src/core/src/time/ecal_timegate.cpp
@@ -21,6 +21,7 @@
  * @brief  eCAL time gateway class
 **/
 
+#include <atomic>
 #include <ecal/ecal.h>
 
 #include <ecal/ecal_config.h>
@@ -31,6 +32,7 @@
 #include "util/getenvvar.h"
 
 #include <chrono>
+#include <string>
 
 #define etime_initialize_name            "etime_initialize"
 #define etime_finalize_name              "etime_finalize"

--- a/src/core/src/time/ecal_timegate.h
+++ b/src/core/src/time/ecal_timegate.h
@@ -28,6 +28,7 @@
 #include "ecal_global_accessors.h"
 
 #include <atomic>
+#include <string>
 
 #ifdef ECAL_OS_WINDOWS
 

--- a/src/core/src/time/ecal_timer.cpp
+++ b/src/core/src/time/ecal_timer.cpp
@@ -24,9 +24,10 @@
 #include <ecal/ecal.h>
 
 #include <atomic>
-#include <chrono>
-#include <thread>
 #include <cassert>
+#include <chrono>
+#include <memory>
+#include <thread>
 
 namespace eCAL
 {

--- a/src/core/src/util/advanced_tclap_output.cpp
+++ b/src/core/src/util/advanced_tclap_output.cpp
@@ -19,7 +19,13 @@
 
 #include "advanced_tclap_output.h"
 
+#include <cstddef>
+#include <list>
+#include <ostream>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace CustomTclap
 {

--- a/src/core/src/util/ecal_expmap.h
+++ b/src/core/src/util/ecal_expmap.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <map>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <chrono>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/include/ecal/service/client_manager.h
+++ b/src/service/ecal_service/include/ecal/service/client_manager.h
@@ -19,10 +19,14 @@
 
 #pragma once
 
-#include <memory>
+#include <cstddef>
+#include <cstdint>
 #include <map>
+#include <memory>
 
 #include <ecal/service/client_session.h>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/include/ecal/service/client_session.h
+++ b/src/service/ecal_service/include/ecal/service/client_session.h
@@ -19,7 +19,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/src/service/ecal_service/include/ecal/service/server.h
+++ b/src/service/ecal_service/include/ecal/service/server.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
 
 #include <asio.hpp>

--- a/src/service/ecal_service/include/ecal/service/server_manager.h
+++ b/src/service/ecal_service/include/ecal/service/server_manager.h
@@ -19,10 +19,13 @@
 
 #pragma once
 
-#include <memory>
+#include <cstddef>
+#include <cstdint>
 #include <map>
+#include <memory>
 
 #include <ecal/service/server.h>
+#include <mutex>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/client_manager.cpp
+++ b/src/service/ecal_service/src/client_manager.cpp
@@ -17,7 +17,13 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/service/client_manager.h>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/client_session.cpp
+++ b/src/service/ecal_service/src/client_session.cpp
@@ -17,7 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstdint>
 #include <ecal/service/client_session.h>
+#include <memory>
+#include <mutex>
+#include <string>
 
 #include "client_session_impl_v1.h"
 #include "client_session_impl_v0.h"

--- a/src/service/ecal_service/src/client_session_impl_base.h
+++ b/src/service/ecal_service/src/client_session_impl_base.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4834)

--- a/src/service/ecal_service/src/client_session_impl_v0.cpp
+++ b/src/service/ecal_service/src/client_session_impl_v0.cpp
@@ -23,7 +23,13 @@
 #include "log_helpers.h"
 #include "log_defs.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/client_session_impl_v0.h
+++ b/src/service/ecal_service/src/client_session_impl_v0.h
@@ -20,10 +20,13 @@
 #pragma once
 
 #include "client_session_impl_base.h"
+#include <cstdint>
 #include <ecal/service/logger.h>
 
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/client_session_impl_v1.cpp
+++ b/src/service/ecal_service/src/client_session_impl_v1.cpp
@@ -23,7 +23,14 @@
 #include "log_helpers.h"
 #include "log_defs.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/client_session_impl_v1.h
+++ b/src/service/ecal_service/src/client_session_impl_v1.h
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "client_session_impl_base.h"
+#include <atomic>
+#include <cstdint>
 #include <ecal/service/logger.h>
 
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/log_helpers.h
+++ b/src/service/ecal_service/src/log_helpers.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <asio.hpp>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/protocol_v0.cpp
+++ b/src/service/ecal_service/src/protocol_v0.cpp
@@ -20,6 +20,11 @@
 #include "protocol_v0.h"
 
 #include "protocol_layout.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/protocol_v0.h
+++ b/src/service/ecal_service/src/protocol_v0.h
@@ -19,11 +19,10 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
 #include <functional>
+#include <memory>
 #include <mutex>
+#include <string>
 
 #include <asio.hpp>
 

--- a/src/service/ecal_service/src/protocol_v1.cpp
+++ b/src/service/ecal_service/src/protocol_v1.cpp
@@ -20,6 +20,12 @@
 #include "protocol_v1.h"
 
 #include "protocol_layout.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/server.cpp
+++ b/src/service/ecal_service/src/server.cpp
@@ -17,9 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstdint>
 #include <ecal/service/server.h>
 
 #include <algorithm>
+#include <memory>
 
 #include "server_impl.h"
 

--- a/src/service/ecal_service/src/server_impl.cpp
+++ b/src/service/ecal_service/src/server_impl.cpp
@@ -20,6 +20,9 @@
 #include "server_impl.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
 
 #include "server_session_impl_v1.h"
 #include "server_session_impl_v0.h"

--- a/src/service/ecal_service/src/server_impl.h
+++ b/src/service/ecal_service/src/server_impl.h
@@ -19,11 +19,13 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
-#include <memory>
 #include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/src/service/ecal_service/src/server_manager.cpp
+++ b/src/service/ecal_service/src/server_manager.cpp
@@ -17,7 +17,12 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/service/server_manager.h>
+#include <map>
+#include <memory>
+#include <mutex>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/server_session_impl_base.h
+++ b/src/service/ecal_service/src/server_session_impl_base.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <functional>
 
-#include <string>
+#include <mutex>
 #include <sstream>
 
 #ifdef _MSC_VER

--- a/src/service/ecal_service/src/server_session_impl_v0.cpp
+++ b/src/service/ecal_service/src/server_session_impl_v0.cpp
@@ -23,6 +23,12 @@
 #include "log_defs.h"
 
 #include "protocol_layout.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 ///////////////////////////////////////////////
 // Create, Constructor, Destructor

--- a/src/service/ecal_service/src/server_session_impl_v0.h
+++ b/src/service/ecal_service/src/server_session_impl_v0.h
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "server_session_impl_base.h"
+#include <atomic>
+#include <cstddef>
 #include <ecal/service/logger.h>
 #include <ecal/service/server_session_types.h>
 
 #include <ecal/service/state.h>
+#include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/ecal_service/src/server_session_impl_v1.cpp
+++ b/src/service/ecal_service/src/server_session_impl_v1.cpp
@@ -21,8 +21,14 @@
 
 #include "protocol_v1.h"
 
-#include "log_helpers.h"
 #include "log_defs.h"
+#include "log_helpers.h"
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 ///////////////////////////////////////////////
 // Create, Constructor, Destructor

--- a/src/service/ecal_service/src/server_session_impl_v1.h
+++ b/src/service/ecal_service/src/server_session_impl_v1.h
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "server_session_impl_base.h"
+#include <atomic>
+#include <cstdint>
 #include <ecal/service/logger.h>
 #include <ecal/service/server_session_types.h>
 
 #include <ecal/service/state.h>
+#include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/src/service/test/src/ecal_tcp_service_test.cpp
+++ b/src/service/test/src/ecal_tcp_service_test.cpp
@@ -21,10 +21,11 @@
 
 #include <asio.hpp>
 
-#include <iostream>
 #include <atomic>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
 
 #include <ecal/service/server.h> // Should not be needed, when I use the server manager / client manager
 #include <ecal/service/client_session.h> // Should not be needed, when I use the server manager / client manager

--- a/src/time/linuxptp/src/config/config.h
+++ b/src/time/linuxptp/src/config/config.h
@@ -21,10 +21,11 @@
 
 #include <SimpleIni.h>
 
-#include <iostream>
-#include <unistd.h>
-#include <sys/types.h>
 #include <ecal/ecal_util.h>
+#include <iostream>
+#include <string>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace LinuxPtpConfig {
 

--- a/src/time/linuxptp/src/ecal_time_linuxptp.cpp
+++ b/src/time/linuxptp/src/ecal_time_linuxptp.cpp
@@ -19,14 +19,16 @@
 
 #include "ecal_time_linuxptp.h"
 
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <unistd.h>
-#include <time.h>
-#include <linux/ptp_clock.h>
 #include <errno.h>
-#include <string.h>
+#include <fcntl.h>
 #include <iostream>
+#include <linux/ptp_clock.h>
+#include <mutex>
+#include <string.h>
+#include <string>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <unistd.h>
 
 Linuxptp::Linuxptp():
   is_initialized(false),

--- a/src/time/linuxptp/src/ecal_time_linuxptp.h
+++ b/src/time/linuxptp/src/ecal_time_linuxptp.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
-#include <time.h>
+#include <bits/types/clockid_t.h>
 #include <mutex>
 #include <string>
+#include <time.h>
 
 #define CLOCKFD 3
 #define FD_TO_CLOCKID(fd)   ((~(clockid_t) (fd) << 3) | CLOCKFD)

--- a/src/time/linuxptp/src/ecaltime.cpp
+++ b/src/time/linuxptp/src/ecaltime.cpp
@@ -17,8 +17,10 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include <ecaltime.h>
 #include <chrono>
+#include <cstring>
+#include <ecaltime.h>
+#include <string>
 #include <thread>
 
 #include "ecal_time_linuxptp.h"

--- a/src/utils/include/ecal_utils/filesystem.h
+++ b/src/utils/include/ecal_utils/filesystem.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 #include <sys/stat.h>
 

--- a/src/utils/include/ecal_utils/string.h
+++ b/src/utils/include/ecal_utils/string.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include <algorithm>

--- a/src/utils/src/filesystem.cpp
+++ b/src/utils/src/filesystem.cpp
@@ -17,7 +17,14 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include "ecal_utils/string.h"
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
 #include <ecal_utils/filesystem.h>
+#include <map>
+#include <string>
+#include <vector>
 
 #ifdef _WIN32
   #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
- based on ecal-io pr https://github.com/ecal-io/ecal-cop/pull/38
- apply the IWYU pragma, focus on std headers, as those don't come with umbrella headers